### PR TITLE
fix(dorm): warehouse-use / warehouse-form 상단 레이아웃 일치 + 카드 클릭 비활성화

### DIFF
--- a/src/pages/dorm/dorm-index.tsx
+++ b/src/pages/dorm/dorm-index.tsx
@@ -6,49 +6,51 @@ import { Card, CardContent } from '@/components/ui/card';
 export default function DormIndexPage() {
   return (
     <Layout>
-      <section className="px-4 py-10 md:py-14">
-        <div className="mx-auto max-w-[1100px] mb-8">
-          <div className="flex items-center gap-3">
-            <img
-              src="/images/schools/gist.svg"
-              alt="GIST logo"
-              className="h-10 w-auto"
-            />
-            <p className="text-4xl font-semibold">GIST</p>
+      <section className="py-10 md:py-14">
+        <div className="max-w-7xl mx-auto px-6 md:px-12 lg:px-24 xl:px-48">
+          <div className="mb-8">
+            <div className="flex items-center gap-3">
+              <img
+                src="/images/schools/gist.svg"
+                alt="GIST logo"
+                className="h-10 w-auto"
+              />
+              <p className="text-4xl font-semibold">GIST</p>
+            </div>
+            <p className="mt-1 text-2xl text-blue-600">
+              Make campus life more convenient
+            </p>
           </div>
-          <p className="mt-1 text-2xl text-blue-600">
-            Make campus life more convenient
-          </p>
-        </div>
 
-        <div className="mx-auto w-full max-w-[1100px] rounded-3xl bg-[#CFEBFF] min-h-[520px] md:min-h-[600px] px-6 md:px-10 pt-8 md:pt-12 pb-10">
-          <div className="mx-auto w-full max-w-[920px]">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-              <Link
-                to="/dorm/retirement-maintenance"
-                className="block focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-2xl"
-              >
-                <Card className="rounded-2xl shadow-lg hover:shadow-2xl transition-shadow">
-                  <CardContent className="p-8 md:p-10">
-                    <div className="text-center text-lg md:text-2xl font-semibold leading-snug">
-                      Application for Retirement <br /> Maintenance Inspection
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
+          <div className="mx-auto w-full max-w-[1100px] rounded-3xl bg-[#CFEBFF] min-h-[520px] md:min-h-[600px] px-6 md:px-10 pt-8 md:pt-12 pb-10">
+            <div className="mx-auto w-full max-w-[920px]">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                <Link
+                  to="/dorm/retirement-maintenance"
+                  className="block focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-2xl"
+                >
+                  <Card className="rounded-2xl shadow-lg hover:shadow-2xl transition-shadow">
+                    <CardContent className="p-8 md:p-10">
+                      <div className="text-center text-lg md:text-2xl font-semibold leading-snug">
+                        Application for Retirement <br /> Maintenance Inspection
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
 
-              <Link
-                to="/dorm/warehouse"
-                className="block focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-2xl"
-              >
-                <Card className="rounded-2xl shadow-lg hover:shadow-2xl transition-shadow">
-                  <CardContent className="p-8 md:p-10">
-                    <div className="text-center text-lg md:text-2xl font-semibold leading-snug">
-                      Application for <br /> warehouse use
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
+                <Link
+                  to="/dorm/warehouse"
+                  className="block focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-2xl"
+                >
+                  <Card className="rounded-2xl shadow-lg hover:shadow-2xl transition-shadow">
+                    <CardContent className="p-8 md:p-10">
+                      <div className="text-center text-lg md:text-2xl font-semibold leading-snug">
+                        Application for <br /> warehouse use
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/dorm/retirement-form.tsx
+++ b/src/pages/dorm/retirement-form.tsx
@@ -53,7 +53,7 @@ export default function RetirementFormPage() {
   return (
     <Layout>
       <section className="mx-auto max-w-6xl px-4 py-10 md:py-14">
-        <h1 className="text-2xl md:text-3xl font-semibold">
+        <h1 className="text-[28px] md:text-[32px] font-extrabold tracking-tight">
           Dormitory : Application for Retirement / Maintenance Inspection
         </h1>
         <p className="mt-2 text-[15px] md:text-base text-neutral-600">

--- a/src/pages/dorm/retirement-maintenance.tsx
+++ b/src/pages/dorm/retirement-maintenance.tsx
@@ -65,20 +65,20 @@ export default function RetirementMaintenanceIntroPage() {
 function RowItem({ row }: { row: Row }) {
   return (
     <>
-      <Link
-        to={row.to}
-        className="block focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-2xl"
-      >
-        <Card className="rounded-2xl border-2 border-blue-400/70 shadow-sm hover:shadow-md transition-shadow">
+      <div className="rounded-2xl">
+        <Card className="rounded-2xl border-2 border-blue-400/70 shadow-sm cursor-default select-none">
           <CardContent className="h-24 md:h-28 flex items-center justify-center p-6 md:p-8">
             <div className="text-[18px] md:text-[22px] font-semibold text-center leading-snug">
               {row.title}
             </div>
           </CardContent>
         </Card>
-      </Link>
+      </div>
 
-      <div className="hidden md:flex items-center justify-center">
+      <div
+        className="hidden md:flex items-center justify-center"
+        aria-hidden="true"
+      >
         <ArrowRight className="h-6 w-6 text-blue-500" />
       </div>
 

--- a/src/pages/dorm/warehouse-form.tsx
+++ b/src/pages/dorm/warehouse-form.tsx
@@ -1,4 +1,3 @@
-// src/pages/dorm/warehouse-form.tsx
 import { useState } from 'react';
 
 import { Layout } from '@/components';
@@ -49,18 +48,18 @@ export default function WarehouseFormPage() {
 
   return (
     <Layout>
-      <section className="mx-auto w-full max-w-7xl px-6 md:px-10 py-14 md:py-16">
-        <div className="mx-auto w-full max-w-[880px]">
-          <h1 className="text-3xl md:text-4xl font-semibold">
-            Dormitory : Application for warehouse use
-          </h1>
-          <p className="mt-3 text-[15px] md:text-base text-neutral-600">
-            All tasks must be applied at least before 8 p.m. the day before.
-            Please note that the work received after 8 p.m. can be processed the
-            next day.
-          </p>
+      <section className="mx-auto max-w-6xl px-4 py-10 md:py-14">
+        <h1 className="text-[28px] md:text-[32px] font-extrabold tracking-tight">
+          Dormitory : Application for warehouse use
+        </h1>
+        <p className="mt-3 text-neutral-600">
+          All tasks must be applied at least before 8 p.m. the day before.{' '}
+          <br />
+          Please note that the work received after 8 p.m. can be processed the
+          next day.
+        </p>
 
-          {/* 폼만 있는 단일 카드 (우측 설명 없음) */}
+        <div className="mx-auto w-full max-w-5xl">
           <Card className="mt-10 rounded-2xl">
             <CardContent className="p-7 md:p-10">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-8 lg:gap-12">

--- a/src/pages/dorm/warehouse-use.tsx
+++ b/src/pages/dorm/warehouse-use.tsx
@@ -12,7 +12,7 @@ export default function WarehouseUseIntroPage() {
         className="mx-auto max-w-6xl px-4 py-10 md:py-14"
         data-warehouse-guide="true"
       >
-        <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight">
+        <h1 className="text-[28px] md:text-[32px] font-extrabold tracking-tight">
           Dormitory : Application for warehouse use
         </h1>
         <p className="mt-3 text-neutral-600">
@@ -24,7 +24,6 @@ export default function WarehouseUseIntroPage() {
 
         <div className="mt-12 mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-[360px_40px_1fr] gap-10 items-center">
           <Row
-            to="/dorm/warehouse-form"
             title="Put your luggage in"
             sectionTitle="During the semester"
             bullets={[
@@ -37,7 +36,6 @@ export default function WarehouseUseIntroPage() {
           />
 
           <Row
-            to="/dorm/warehouse-form"
             title="Take off your luggage"
             sectionTitle="During vacation"
             bullets={[
@@ -64,23 +62,18 @@ export default function WarehouseUseIntroPage() {
 }
 
 function Row({
-  to,
   title,
   sectionTitle,
   bullets,
 }: {
-  to: string;
   title: string;
   sectionTitle: string;
   bullets: string[];
 }) {
   return (
     <>
-      <Link
-        to={to}
-        className="block focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-2xl mx-auto md:mx-0"
-      >
-        <Card className="rounded-2xl border-2 border-blue-500 shadow-sm hover:shadow-md transition-shadow">
+      <div className="rounded-2xl mx-auto md:mx-0" role="presentation">
+        <Card className="rounded-2xl border-2 border-blue-500 shadow-sm cursor-default select-none">
           <CardContent className="h-24 md:h-28 px-8">
             <div className="h-full w-full flex items-center justify-center">
               <div className="text-xl md:text-2xl font-semibold text-center leading-snug whitespace-nowrap">
@@ -89,9 +82,12 @@ function Row({
             </div>
           </CardContent>
         </Card>
-      </Link>
+      </div>
 
-      <div className="hidden md:flex items-center justify-center" aria-hidden>
+      <div
+        className="hidden md:flex items-center justify-center"
+        aria-hidden="true"
+      >
         <ArrowRight className="h-6 w-6 text-blue-500" />
       </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 기숙사 메인 상단 섹션 레이아웃 개선: 더 넓은 컨테이너와 여백 조정, 헤더에 서브타이틀 노출.
  - 폼/인트로 페이지 타이포그래피 업데이트: 제목 두께·크기 상향, 간격 및 컨테이너 폭 조정, 인트로 문단 가독성 개선.

- 리팩터
  - 카드/행 항목의 클릭 인터랙션 제거: 유지보수/창고 사용 안내 목록이 비클릭형 정적 카드로 변경, 화살표는 장식 처리.
  - 내부 구조 정리로도 기존 그리드/콘텐츠는 유지, 하단 CTA 링크는 그대로 동작.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->